### PR TITLE
Add null check in Camera Mixin rotation method

### DIFF
--- a/src/client/java/io/github/foundationgames/splinecart/mixin/client/CameraMixin.java
+++ b/src/client/java/io/github/foundationgames/splinecart/mixin/client/CameraMixin.java
@@ -52,6 +52,8 @@ public abstract class CameraMixin {
     @Inject(method = "setRotation(FF)V",
             at = @At(value = "INVOKE", shift = At.Shift.AFTER, ordinal = 0, target = "Lorg/joml/Quaternionf;rotationYXZ(FFF)Lorg/joml/Quaternionf;", remap = false))
     private void splinecart$updateCamRotationWhileRiding(float yaw, float pitch, CallbackInfo info) {
+        if (this.focusedEntity == null) return;
+
         var self = this.focusedEntity;
         var vehicle = self.getVehicle();
         var tickDelta = MinecraftClient.getInstance().getRenderTickCounter().getTickDelta(false);


### PR DESCRIPTION
Added a null check in the camera mixin to return early if focusedEntity is null, as it would otherwise cause crashes with mods that use a fake camera context, I.E: Create's Ponder screen.